### PR TITLE
Upgrade to net6

### DIFF
--- a/JOIEnergy.Tests/JOIEnergy.Tests.csproj
+++ b/JOIEnergy.Tests/JOIEnergy.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/JOIEnergy.Tests/JOIEnergy.Tests.csproj
+++ b/JOIEnergy.Tests/JOIEnergy.Tests.csproj
@@ -1,16 +1,18 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0-preview-20170628-02" />
-    <PackageReference Include="xunit" Version="2.2.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
-    <PackageReference Include="Moq" Version="4.8.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3"><IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+<PrivateAssets>all</PrivateAssets>
+</PackageReference>
+    <PackageReference Include="Moq" Version="4.16.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/JOIEnergy.Tests/PricePlanComparisonTest.cs
+++ b/JOIEnergy.Tests/PricePlanComparisonTest.cs
@@ -5,9 +5,7 @@ using JOIEnergy.Services;
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 using Xunit;
-using Xunit.Abstractions;
 using Newtonsoft.Json.Linq;
 
 namespace JOIEnergy.Tests
@@ -40,13 +38,13 @@ namespace JOIEnergy.Tests
             var otherReading = new ElectricityReading() { Time = DateTime.Now, Reading = 5.0m };
             meterReadingService.StoreReadings(SMART_METER_ID, new List<ElectricityReading>() { electricityReading, otherReading });
 
-            var result = controller.CalculatedCostForEachPricePlan(SMART_METER_ID).Value;
+            Dictionary<string, decimal> result = controller.CalculatedCostForEachPricePlan(SMART_METER_ID).Value as Dictionary<string, decimal>;
 
-            var actualCosts = ((JObject)result).ToObject<Dictionary<string, decimal>>();
-            Assert.Equal(3, actualCosts.Count);
-            Assert.Equal(100m, actualCosts["" + Supplier.DrEvilsDarkEnergy], 3);
-            Assert.Equal(20m, actualCosts["" + Supplier.TheGreenEco], 3);
-            Assert.Equal(10m, actualCosts["" + Supplier.PowerForEveryone], 3);
+            Assert.NotNull(result);
+            Assert.Equal(3, result.Count);
+            Assert.Equal(100m, result[Supplier.DrEvilsDarkEnergy.ToString()], 3);
+            Assert.Equal(20m, result[Supplier.TheGreenEco.ToString()], 3);
+            Assert.Equal(10m, result[Supplier.PowerForEveryone.ToString()], 3);
         }
 
         [Fact]

--- a/JOIEnergy/Controllers/PricePlanComparatorController.cs
+++ b/JOIEnergy/Controllers/PricePlanComparatorController.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
+using JOIEnergy.Enums;
 using JOIEnergy.Services;
 using Microsoft.AspNetCore.Mvc;
 using Newtonsoft.Json.Linq;
@@ -23,8 +24,8 @@ namespace JOIEnergy.Controllers
         [HttpGet("compare-all/{smartMeterId}")]
         public ObjectResult CalculatedCostForEachPricePlan(string smartMeterId)
         {
-            var pricePlanId = _accountService.GetPricePlanIdForSmartMeterId(smartMeterId);
-            var costPerPricePlan = _pricePlanService.GetConsumptionCostOfElectricityReadingsForEachPricePlan(smartMeterId);
+            Supplier pricePlanId = _accountService.GetPricePlanIdForSmartMeterId(smartMeterId);
+            Dictionary<string, decimal> costPerPricePlan = _pricePlanService.GetConsumptionCostOfElectricityReadingsForEachPricePlan(smartMeterId);
             if (!costPerPricePlan.Any())
             {
                 return new NotFoundObjectResult(string.Format("Smart Meter ID ({0}) not found", smartMeterId));

--- a/JOIEnergy/Controllers/PricePlanComparatorController.cs
+++ b/JOIEnergy/Controllers/PricePlanComparatorController.cs
@@ -30,11 +30,9 @@ namespace JOIEnergy.Controllers
                 return new NotFoundObjectResult(string.Format("Smart Meter ID ({0}) not found", smartMeterId));
             }
 
-            dynamic response = JObject.FromObject(costPerPricePlan);
-
             return
                 costPerPricePlan.Any() ? 
-                new ObjectResult(response) : 
+                new ObjectResult(costPerPricePlan) : 
                 new NotFoundObjectResult(string.Format("Smart Meter ID ({0}) not found", smartMeterId));
         }
 

--- a/JOIEnergy/JOIEnergy.csproj
+++ b/JOIEnergy/JOIEnergy.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/JOIEnergy/JOIEnergy.csproj
+++ b/JOIEnergy/JOIEnergy.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
@@ -13,7 +13,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.9" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/JOIEnergy/Properties/launchSettings.json
+++ b/JOIEnergy/Properties/launchSettings.json
@@ -11,7 +11,6 @@
     "IIS Express": {
       "commandName": "IISExpress",
       "launchBrowser": true,
-      "launchUrl": "api/values",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       }
@@ -19,11 +18,10 @@
     "JOIEnergy": {
       "commandName": "Project",
       "launchBrowser": true,
-      "launchUrl": "api/values",
+      "applicationUrl": "http://localhost:5000/",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
-      },
-      "applicationUrl": "http://localhost:5000/"
+      }
     }
   }
 }

--- a/JOIEnergy/Startup.cs
+++ b/JOIEnergy/Startup.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Threading.Tasks;
 using JOIEnergy.Domain;
 using JOIEnergy.Enums;
 using JOIEnergy.Generator;
@@ -9,9 +8,8 @@ using JOIEnergy.Services;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Options;
 
 namespace JOIEnergy
 {
@@ -48,7 +46,7 @@ namespace JOIEnergy
                 }
             };
 
-            services.AddMvc();
+            services.AddMvc(options => options.EnableEndpointRouting = false);
             services.AddTransient<IAccountService, AccountService>();
             services.AddTransient<IMeterReadingService, MeterReadingService>();
             services.AddTransient<IPricePlanService, PricePlanService>();
@@ -58,7 +56,7 @@ namespace JOIEnergy
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
-        public void Configure(IApplicationBuilder app, IHostingEnvironment env)
+        public void Configure(IApplicationBuilder app, IWebHostEnvironment env)
         {
             if (env.IsDevelopment())
             {

--- a/README.md
+++ b/README.md
@@ -202,17 +202,19 @@ Example output
 
 ## Requirements
 
-The project requires [.NET Core 2.0](https://dotnet.microsoft.com/download/dotnet-core/2.0). Kindly note that this project may not work with newer versions of .NET.
+The project requires [.NET 6.0](https://dotnet.microsoft.com/en-us/download/dotnet/6.0).
 
 ## Compatible IDEs
 
 Tested on:
 
-- Visual Studio 2017 Community edition on Windows (15.5.2)
-- Visual Studio for Mac
-- Visual Studio Code 1.52.0 (with C# OmniSharp extension)
+- Visual Studio 2022 (17.1)
+- Visual Studio for Mac (8.10)
+- Visual Studio Code (1.64)
 
 ## Useful commands
+
+From the terminal/shell/command line tool, use the following commands to build, test and run the API.
 
 ### Build the project
 
@@ -233,5 +235,3 @@ Run the application which will be listening on port `5000`.
 ```console
 $ dotnet run --project JOIEnergy
 ```
-
-If you're running from Visual Studio the default url might be `http://localhost:5000/api/values`. If that's the case, then you need to remove the `api/values` part from the URL.


### PR DESCRIPTION
API and Test projects have been updated to .NET 6. Code changes were necessary to adapt to the new version:

- Changed `IHostingEnvironment` for `IWebHostEnvironment`
- Set `MvcOptions.EnableEndpointRouting` to `false`
- Reference `Newtonsoft.Json` package
- In `CalculatedCostForEachPricePlan` return `Dictionary<string, decimal>` instead of `JObject`

Updated NuGet packages in the test project to the latest stable version.

Updated README.md to reflect the new requirements.