### PR TITLE
Fix inconsistency with Java version that makes it much harder to solve the task

### DIFF
--- a/JOIEnergy.Tests/AccountServiceTest.cs
+++ b/JOIEnergy.Tests/AccountServiceTest.cs
@@ -8,14 +8,14 @@ namespace JOIEnergy.Tests
 {
     public class AccountServiceTest
     {
-        private const Supplier PRICE_PLAN_ID = Supplier.PowerForEveryone;
+        private const String PRICE_PLAN_ID = "price-plan-id";
         private const String SMART_METER_ID = "smart-meter-id";
 
         private AccountService accountService;
 
         public AccountServiceTest()
         {
-            Dictionary<String, Supplier> smartMeterToPricePlanAccounts = new Dictionary<string, Supplier>();
+            var smartMeterToPricePlanAccounts = new Dictionary<string, string>();
             smartMeterToPricePlanAccounts.Add(SMART_METER_ID, PRICE_PLAN_ID);
 
             accountService = new AccountService(smartMeterToPricePlanAccounts);
@@ -24,15 +24,16 @@ namespace JOIEnergy.Tests
         [Fact]
         public void GivenTheSmartMeterIdReturnsThePricePlanId()
         {
-            var result = accountService.GetPricePlanIdForSmartMeterId("smart-meter-id");
-            Assert.Equal(Supplier.PowerForEveryone, result);
+            var result = accountService.GetPricePlanIdForSmartMeterId(SMART_METER_ID);
+            Assert.Equal(PRICE_PLAN_ID, result);
+        }
+        
+        [Fact]
+        public void GivenAnUnknownSmartMeterIdReturnsNull()
+        {
+            var result = accountService.GetPricePlanIdForSmartMeterId("non-existent");
+            Assert.Null(result);
         }
 
-        [Fact]
-        public void GivenAnUnknownSmartMeterIdReturnsANullSupplier()
-        {
-            var result = accountService.GetPricePlanIdForSmartMeterId("bob-carolgees");
-            Assert.Equal(Supplier.NullSupplier, result);
-        }
     }
 }

--- a/JOIEnergy.Tests/AccountServiceTest.cs
+++ b/JOIEnergy.Tests/AccountServiceTest.cs
@@ -8,8 +8,8 @@ namespace JOIEnergy.Tests
 {
     public class AccountServiceTest
     {
-        private const String PRICE_PLAN_ID = "price-plan-id";
-        private const String SMART_METER_ID = "smart-meter-id";
+        private const string PRICE_PLAN_ID = "price-plan-id";
+        private const string SMART_METER_ID = "smart-meter-id";
 
         private AccountService accountService;
 

--- a/JOIEnergy.Tests/PricePlanComparisonTest.cs
+++ b/JOIEnergy.Tests/PricePlanComparisonTest.cs
@@ -16,10 +16,10 @@ namespace JOIEnergy.Tests
         private MeterReadingService meterReadingService;
         private PricePlanComparatorController controller;
 
-        private static String PRICE_PLAN_1_ID = "test-supplier";
-        private static String PRICE_PLAN_2_ID = "best-supplier";
-        private static String PRICE_PLAN_3_ID = "second-best-supplier";
-        private static String SMART_METER_ID = "smart-meter-id";
+        private static string PRICE_PLAN_1_ID = "test-supplier";
+        private static string PRICE_PLAN_2_ID = "best-supplier";
+        private static string PRICE_PLAN_3_ID = "second-best-supplier";
+        private static string SMART_METER_ID = "smart-meter-id";
 
         public PricePlanComparisonTest()
         {

--- a/JOIEnergy.Tests/PricePlanComparisonTest.cs
+++ b/JOIEnergy.Tests/PricePlanComparisonTest.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Xunit;
 using Newtonsoft.Json.Linq;
+using System.Collections;
 
 namespace JOIEnergy.Tests
 {
@@ -14,7 +15,10 @@ namespace JOIEnergy.Tests
     {
         private MeterReadingService meterReadingService;
         private PricePlanComparatorController controller;
-        private Dictionary<string, string> smartMeterToPricePlanAccounts = new Dictionary<string, string>();
+
+        private static String PRICE_PLAN_1_ID = "test-supplier";
+        private static String PRICE_PLAN_2_ID = "best-supplier";
+        private static String PRICE_PLAN_3_ID = "second-best-supplier";
         private static String SMART_METER_ID = "smart-meter-id";
 
         public PricePlanComparisonTest()
@@ -22,11 +26,15 @@ namespace JOIEnergy.Tests
             var readings = new Dictionary<string, List<Domain.ElectricityReading>>();
             meterReadingService = new MeterReadingService(readings);
             var pricePlans = new List<PricePlan>() { 
-                new PricePlan() { EnergySupplier = Supplier.DrEvilsDarkEnergy, UnitRate = 10, PeakTimeMultiplier = NoMultipliers() }, 
-                new PricePlan() { EnergySupplier = Supplier.TheGreenEco, UnitRate = 2, PeakTimeMultiplier = NoMultipliers() },
-                new PricePlan() { EnergySupplier = Supplier.PowerForEveryone, UnitRate = 1, PeakTimeMultiplier = NoMultipliers() } 
+                new PricePlan() { PlanName = PRICE_PLAN_1_ID, UnitRate = 10, PeakTimeMultiplier = NoMultipliers() }, 
+                new PricePlan() { PlanName = PRICE_PLAN_2_ID, UnitRate = 1, PeakTimeMultiplier = NoMultipliers() },
+                new PricePlan() { PlanName = PRICE_PLAN_3_ID, UnitRate = 2, PeakTimeMultiplier = NoMultipliers() } 
             };
             var pricePlanService = new PricePlanService(pricePlans, meterReadingService);
+            var smartMeterToPricePlanAccounts = new Dictionary<string, string>
+            {
+                { SMART_METER_ID, PRICE_PLAN_1_ID }
+            };
             var accountService = new AccountService(smartMeterToPricePlanAccounts);
             controller = new PricePlanComparatorController(pricePlanService, accountService);
         }
@@ -38,13 +46,16 @@ namespace JOIEnergy.Tests
             var otherReading = new ElectricityReading() { Time = DateTime.Now, Reading = 5.0m };
             meterReadingService.StoreReadings(SMART_METER_ID, new List<ElectricityReading>() { electricityReading, otherReading });
 
-            Dictionary<string, decimal> result = controller.CalculatedCostForEachPricePlan(SMART_METER_ID).Value as Dictionary<string, decimal>;
+            Dictionary<string, object> result = controller.CalculatedCostForEachPricePlan(SMART_METER_ID).Value as Dictionary<string, object>;
 
             Assert.NotNull(result);
-            Assert.Equal(3, result.Count);
-            Assert.Equal(100m, result[Supplier.DrEvilsDarkEnergy.ToString()], 3);
-            Assert.Equal(20m, result[Supplier.TheGreenEco.ToString()], 3);
-            Assert.Equal(10m, result[Supplier.PowerForEveryone.ToString()], 3);
+            Assert.Equal(PRICE_PLAN_1_ID, result[PricePlanComparatorController.PRICE_PLAN_ID_KEY]);
+            var expected = new Dictionary<string, decimal>() {
+                { PRICE_PLAN_1_ID, 100m },
+                { PRICE_PLAN_2_ID, 10m },
+                { PRICE_PLAN_3_ID, 20m },
+            };
+            Assert.Equal(expected, result[PricePlanComparatorController.PRICE_PLAN_COMPARISONS_KEY]);
         }
 
         [Fact]
@@ -56,15 +67,14 @@ namespace JOIEnergy.Tests
             });
 
             object result = controller.RecommendCheapestPricePlans(SMART_METER_ID, null).Value;
-            var recommendations = ((IEnumerable<KeyValuePair<string, decimal>>)result).ToList();
 
-            Assert.Equal("" + Supplier.PowerForEveryone, recommendations[0].Key);
-            Assert.Equal("" + Supplier.TheGreenEco, recommendations[1].Key);
-            Assert.Equal("" + Supplier.DrEvilsDarkEnergy, recommendations[2].Key);
-            Assert.Equal(38m, recommendations[0].Value, 3);
-            Assert.Equal(76m, recommendations[1].Value, 3);
-            Assert.Equal(380m, recommendations[2].Value, 3);
-            Assert.Equal(3, recommendations.Count);
+            var recommendations = ((IEnumerable<KeyValuePair<string, decimal>>)result).ToList();
+            var expected = new List<KeyValuePair<string, decimal>>() {
+                new(PRICE_PLAN_2_ID, 38m),
+                new(PRICE_PLAN_3_ID, 76m),
+                new(PRICE_PLAN_1_ID, 380m),
+            };
+            Assert.Equal(expected, recommendations);
         }
 
         [Fact]
@@ -76,27 +86,32 @@ namespace JOIEnergy.Tests
             });
 
             object result = controller.RecommendCheapestPricePlans(SMART_METER_ID, 2).Value;
-            var recommendations = ((IEnumerable<KeyValuePair<string, decimal>>)result).ToList();
 
-            Assert.Equal("" + Supplier.PowerForEveryone, recommendations[0].Key);
-            Assert.Equal("" + Supplier.TheGreenEco, recommendations[1].Key);
-            Assert.Equal(16.667m, recommendations[0].Value, 3);
-            Assert.Equal(33.333m, recommendations[1].Value, 3);
-            Assert.Equal(2, recommendations.Count);
+            var recommendations = ((IEnumerable<KeyValuePair<string, decimal>>)result).ToList();
+            var expected = new List<KeyValuePair<string, decimal>>() {
+                new(PRICE_PLAN_2_ID, 16.667m),
+                new(PRICE_PLAN_3_ID, 33.333m),
+            };
+            Assert.Equal(expected, recommendations);
         }
 
         [Fact]
         public void ShouldRecommendCheapestPricePlansMoreThanLimitAvailableForMeterUsage()
         {
             meterReadingService.StoreReadings(SMART_METER_ID, new List<ElectricityReading>() {
-                new ElectricityReading() { Time = DateTime.Now.AddMinutes(-30), Reading = 35m },
+                new ElectricityReading() { Time = DateTime.Now.AddMinutes(-60), Reading = 25m },
                 new ElectricityReading() { Time = DateTime.Now, Reading = 3m }
             });
 
             object result = controller.RecommendCheapestPricePlans(SMART_METER_ID, 5).Value;
-            var recommendations = ((IEnumerable<KeyValuePair<string, decimal>>)result).ToList();
 
-            Assert.Equal(3, recommendations.Count);
+            var recommendations = ((IEnumerable<KeyValuePair<string, decimal>>)result).ToList();
+            var expected = new List<KeyValuePair<string, decimal>>() {
+                new(PRICE_PLAN_2_ID, 14m),
+                new(PRICE_PLAN_3_ID, 28m),
+                new(PRICE_PLAN_1_ID, 140m),
+            };
+            Assert.Equal(expected, recommendations);
         }
 
         [Fact]

--- a/JOIEnergy.Tests/PricePlanComparisonTest.cs
+++ b/JOIEnergy.Tests/PricePlanComparisonTest.cs
@@ -14,7 +14,7 @@ namespace JOIEnergy.Tests
     {
         private MeterReadingService meterReadingService;
         private PricePlanComparatorController controller;
-        private Dictionary<string, Supplier> smartMeterToPricePlanAccounts = new Dictionary<string, Supplier>();
+        private Dictionary<string, string> smartMeterToPricePlanAccounts = new Dictionary<string, string>();
         private static String SMART_METER_ID = "smart-meter-id";
 
         public PricePlanComparisonTest()

--- a/JOIEnergy/Controllers/MeterReadingController.cs
+++ b/JOIEnergy/Controllers/MeterReadingController.cs
@@ -32,7 +32,7 @@ namespace JOIEnergy.Controllers
 
         private bool IsMeterReadingsValid(MeterReadings meterReadings)
         {
-            String smartMeterId = meterReadings.SmartMeterId;
+            string smartMeterId = meterReadings.SmartMeterId;
             List<ElectricityReading> electricityReadings = meterReadings.ElectricityReadings;
             return smartMeterId != null && smartMeterId.Any()
                     && electricityReadings != null && electricityReadings.Any();

--- a/JOIEnergy/Controllers/PricePlanComparatorController.cs
+++ b/JOIEnergy/Controllers/PricePlanComparatorController.cs
@@ -24,7 +24,7 @@ namespace JOIEnergy.Controllers
         [HttpGet("compare-all/{smartMeterId}")]
         public ObjectResult CalculatedCostForEachPricePlan(string smartMeterId)
         {
-            Supplier pricePlanId = _accountService.GetPricePlanIdForSmartMeterId(smartMeterId);
+            string pricePlanId = _accountService.GetPricePlanIdForSmartMeterId(smartMeterId);
             Dictionary<string, decimal> costPerPricePlan = _pricePlanService.GetConsumptionCostOfElectricityReadingsForEachPricePlan(smartMeterId);
             if (!costPerPricePlan.Any())
             {

--- a/JOIEnergy/Controllers/PricePlanComparatorController.cs
+++ b/JOIEnergy/Controllers/PricePlanComparatorController.cs
@@ -12,6 +12,8 @@ namespace JOIEnergy.Controllers
     [Route("price-plans")]
     public class PricePlanComparatorController : Controller
     {
+        public const string PRICE_PLAN_ID_KEY = "pricePlanId";
+        public const string PRICE_PLAN_COMPARISONS_KEY = "pricePlanComparisons";
         private readonly IPricePlanService _pricePlanService;
         private readonly IAccountService _accountService;
 
@@ -31,10 +33,10 @@ namespace JOIEnergy.Controllers
                 return new NotFoundObjectResult(string.Format("Smart Meter ID ({0}) not found", smartMeterId));
             }
 
-            return
-                costPerPricePlan.Any() ? 
-                new ObjectResult(costPerPricePlan) : 
-                new NotFoundObjectResult(string.Format("Smart Meter ID ({0}) not found", smartMeterId));
+            return new ObjectResult(new Dictionary<string, object>() {
+                {PRICE_PLAN_ID_KEY, pricePlanId},
+                {PRICE_PLAN_COMPARISONS_KEY, costPerPricePlan},
+            });
         }
 
         [HttpGet("recommend/{smartMeterId}")]

--- a/JOIEnergy/Domain/PricePlan.cs
+++ b/JOIEnergy/Domain/PricePlan.cs
@@ -7,6 +7,7 @@ namespace JOIEnergy.Domain
 {
     public class PricePlan
     {
+        public String PlanName { get; set; }
         public Supplier EnergySupplier { get; set; }
         public decimal UnitRate { get; set; }
         public IList<PeakTimeMultiplier> PeakTimeMultiplier { get; set;}

--- a/JOIEnergy/Domain/PricePlan.cs
+++ b/JOIEnergy/Domain/PricePlan.cs
@@ -7,7 +7,7 @@ namespace JOIEnergy.Domain
 {
     public class PricePlan
     {
-        public String PlanName { get; set; }
+        public string PlanName { get; set; }
         public Supplier EnergySupplier { get; set; }
         public decimal UnitRate { get; set; }
         public IList<PeakTimeMultiplier> PeakTimeMultiplier { get; set;}

--- a/JOIEnergy/Services/AccountService.cs
+++ b/JOIEnergy/Services/AccountService.cs
@@ -4,18 +4,18 @@ using JOIEnergy.Enums;
 
 namespace JOIEnergy.Services
 {
-    public class AccountService : Dictionary<string, Supplier>, IAccountService
+    public class AccountService : IAccountService
     { 
-        private Dictionary<string, Supplier> _smartMeterToPricePlanAccounts;
+        private Dictionary<string, string> _smartMeterToPricePlanAccounts;
 
-        public AccountService(Dictionary<string, Supplier> smartMeterToPricePlanAccounts) {
+        public AccountService(Dictionary<string, string> smartMeterToPricePlanAccounts) {
             _smartMeterToPricePlanAccounts = smartMeterToPricePlanAccounts;
         }
 
-        public Supplier GetPricePlanIdForSmartMeterId(string smartMeterId) {
+        public string GetPricePlanIdForSmartMeterId(string smartMeterId) {
             if (!_smartMeterToPricePlanAccounts.ContainsKey(smartMeterId))
             {
-                return Supplier.NullSupplier;
+                return null;
             }
             return _smartMeterToPricePlanAccounts[smartMeterId];
         }

--- a/JOIEnergy/Services/IAccountService.cs
+++ b/JOIEnergy/Services/IAccountService.cs
@@ -4,6 +4,6 @@ namespace JOIEnergy.Services
 {
     public interface IAccountService
     {
-        Supplier GetPricePlanIdForSmartMeterId(string smartMeterId);
+        string GetPricePlanIdForSmartMeterId(string smartMeterId);
     }
 }

--- a/JOIEnergy/Services/PricePlanService.cs
+++ b/JOIEnergy/Services/PricePlanService.cs
@@ -37,7 +37,7 @@ namespace JOIEnergy.Services
             var average = calculateAverageReading(electricityReadings);
             var timeElapsed = calculateTimeElapsed(electricityReadings);
             var averagedCost = average/timeElapsed;
-            return averagedCost * pricePlan.UnitRate;
+            return Math.Round(averagedCost * pricePlan.UnitRate, 3);
         }
 
         public Dictionary<String, decimal> GetConsumptionCostOfElectricityReadingsForEachPricePlan(String smartMeterId)
@@ -48,7 +48,7 @@ namespace JOIEnergy.Services
             {
                 return new Dictionary<string, decimal>();
             }
-            return _pricePlans.ToDictionary(plan => plan.EnergySupplier.ToString(), plan => calculateCost(electricityReadings, plan));
+            return _pricePlans.ToDictionary(plan => plan.PlanName, plan => calculateCost(electricityReadings, plan));
         }
     }
 }

--- a/JOIEnergy/Services/PricePlanService.cs
+++ b/JOIEnergy/Services/PricePlanService.cs
@@ -40,7 +40,7 @@ namespace JOIEnergy.Services
             return Math.Round(averagedCost * pricePlan.UnitRate, 3);
         }
 
-        public Dictionary<String, decimal> GetConsumptionCostOfElectricityReadingsForEachPricePlan(String smartMeterId)
+        public Dictionary<string, decimal> GetConsumptionCostOfElectricityReadingsForEachPricePlan(string smartMeterId)
         {
             List<ElectricityReading> electricityReadings = _meterReadingService.GetReadings(smartMeterId);
 

--- a/JOIEnergy/Startup.cs
+++ b/JOIEnergy/Startup.cs
@@ -14,9 +14,9 @@ namespace JOIEnergy
 {
     public class Startup
     {
-        private const String MOST_EVIL_PRICE_PLAN_ID = "price-plan-0";
-        private const String RENEWABLES_PRICE_PLAN_ID = "price-plan-1";
-        private const String STANDARD_PRICE_PLAN_ID = "price-plan-2";
+        private const string MOST_EVIL_PRICE_PLAN_ID = "price-plan-0";
+        private const string RENEWABLES_PRICE_PLAN_ID = "price-plan-1";
+        private const string STANDARD_PRICE_PLAN_ID = "price-plan-2";
 
         public Startup(IConfiguration configuration)
         {
@@ -84,11 +84,11 @@ namespace JOIEnergy
             return readings;
         }
 
-        public Dictionary<String, String> SmartMeterToPricePlanAccounts
+        public Dictionary<string, string> SmartMeterToPricePlanAccounts
         {
             get
             {
-                Dictionary<String, String> smartMeterToPricePlanAccounts = new Dictionary<string, String>();
+                Dictionary<string, string> smartMeterToPricePlanAccounts = new Dictionary<string, string>();
                 smartMeterToPricePlanAccounts.Add("smart-meter-0", MOST_EVIL_PRICE_PLAN_ID);
                 smartMeterToPricePlanAccounts.Add("smart-meter-1", RENEWABLES_PRICE_PLAN_ID);
                 smartMeterToPricePlanAccounts.Add("smart-meter-2", MOST_EVIL_PRICE_PLAN_ID);

--- a/JOIEnergy/Startup.cs
+++ b/JOIEnergy/Startup.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.Linq;
 using JOIEnergy.Domain;
-using JOIEnergy.Enums;
 using JOIEnergy.Generator;
 using JOIEnergy.Services;
 using Microsoft.AspNetCore.Builder;
@@ -15,6 +14,10 @@ namespace JOIEnergy
 {
     public class Startup
     {
+        private const String MOST_EVIL_PRICE_PLAN_ID = "price-plan-0";
+        private const String RENEWABLES_PRICE_PLAN_ID = "price-plan-1";
+        private const String STANDARD_PRICE_PLAN_ID = "price-plan-2";
+
         public Startup(IConfiguration configuration)
         {
             Configuration = configuration;
@@ -30,16 +33,19 @@ namespace JOIEnergy
 
             var pricePlans = new List<PricePlan> {
                 new PricePlan{
+                    PlanName = MOST_EVIL_PRICE_PLAN_ID,
                     EnergySupplier = Enums.Supplier.DrEvilsDarkEnergy,
                     UnitRate = 10m,
                     PeakTimeMultiplier = new List<PeakTimeMultiplier>()
                 },
                 new PricePlan{
+                    PlanName = RENEWABLES_PRICE_PLAN_ID,
                     EnergySupplier = Enums.Supplier.TheGreenEco,
                     UnitRate = 2m,
                     PeakTimeMultiplier = new List<PeakTimeMultiplier>()
                 },
                 new PricePlan{
+                    PlanName = STANDARD_PRICE_PLAN_ID,
                     EnergySupplier = Enums.Supplier.PowerForEveryone,
                     UnitRate = 1m,
                     PeakTimeMultiplier = new List<PeakTimeMultiplier>()
@@ -78,16 +84,16 @@ namespace JOIEnergy
             return readings;
         }
 
-        public Dictionary<String, Supplier> SmartMeterToPricePlanAccounts
+        public Dictionary<String, String> SmartMeterToPricePlanAccounts
         {
             get
             {
-                Dictionary<String, Supplier> smartMeterToPricePlanAccounts = new Dictionary<string, Supplier>();
-                smartMeterToPricePlanAccounts.Add("smart-meter-0", Supplier.DrEvilsDarkEnergy);
-                smartMeterToPricePlanAccounts.Add("smart-meter-1", Supplier.TheGreenEco);
-                smartMeterToPricePlanAccounts.Add("smart-meter-2", Supplier.DrEvilsDarkEnergy);
-                smartMeterToPricePlanAccounts.Add("smart-meter-3", Supplier.PowerForEveryone);
-                smartMeterToPricePlanAccounts.Add("smart-meter-4", Supplier.TheGreenEco);
+                Dictionary<String, String> smartMeterToPricePlanAccounts = new Dictionary<string, String>();
+                smartMeterToPricePlanAccounts.Add("smart-meter-0", MOST_EVIL_PRICE_PLAN_ID);
+                smartMeterToPricePlanAccounts.Add("smart-meter-1", RENEWABLES_PRICE_PLAN_ID);
+                smartMeterToPricePlanAccounts.Add("smart-meter-2", MOST_EVIL_PRICE_PLAN_ID);
+                smartMeterToPricePlanAccounts.Add("smart-meter-3", STANDARD_PRICE_PLAN_ID);
+                smartMeterToPricePlanAccounts.Add("smart-meter-4", RENEWABLES_PRICE_PLAN_ID);
                 return smartMeterToPricePlanAccounts;
             }
         }


### PR DESCRIPTION
The domain model of the C# version of the codebase associates smart meter IDs with Suppliers; this is inconsistent with the Java version, where the smart meter is associated with a price plan.

Also the compare-all endpoint behaves much differently in the C# version; in Java, one of the returned items is the price plan associated with the smart meter.

The problem statement explicitly requires to find the price plan associated with a smart meter ID, and this is much more difficult in the C# version because of the reasons above.

The changes in this PR make both the domain model and the compare-all endpoint correspond closely to the Java version.