### PR TITLE
Remove exclusion of PricePlanServiceTest

### DIFF
--- a/JOIEnergy.Tests/JOIEnergy.Tests.csproj
+++ b/JOIEnergy.Tests/JOIEnergy.Tests.csproj
@@ -18,7 +18,4 @@
   <ItemGroup>
     <ProjectReference Include="..\JOIEnergy\JOIEnergy.csproj" />
   </ItemGroup>
-  <ItemGroup>
-    <Compile Remove="PricePlanServiceTest.cs" />
-  </ItemGroup>
 </Project>

--- a/JOIEnergy.Tests/PricePlanServiceTest.cs
+++ b/JOIEnergy.Tests/PricePlanServiceTest.cs
@@ -11,7 +11,7 @@ namespace JOIEnergy.Tests
     {
         private PricePlanService _pricePlanService;
         private readonly Mock<MeterReadingService> _mockMeterReadingService;
-        private List<PricePlan> _pricePlans;
+        private List<PricePlan> _pricePlans = [];
 
         public PricePlanServiceTest()
         {


### PR DESCRIPTION
The configuration of the tests project excludes the compilation and listing of the PricePlanServiceTest.cs file in the solutions explorer. This leads to confusion to some candidates as they do not see the file and are not able to create it since it already exists.